### PR TITLE
Chore: Alter multiple things related to CI builds

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -9,12 +9,17 @@ on:
       - packages/**
       - .github/workflows/build-web.yml
   workflow_dispatch:
-    
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REPO_RELPATH: frontend
   APP_RELPATH: apps/android
   APK_RELEASE_DIR_RELPATH: android/app/build/outputs/apk/release
-
+  APK_RELEASE_FILENAME: app-release.apk
+    
 jobs:
   build-android:
     runs-on: ubuntu-latest
@@ -29,7 +34,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-          # repository: utkusarioglu/android
           path: ${{ env.REPO_RELPATH }}
 
       - name: Install monorepo dependencies
@@ -44,13 +48,20 @@ jobs:
         run: |
           yarn build-release
 
-      # - name: Upload to Google Drive
-      #   uses: adityak74/google-drive-upload-git-action@main
-      #   with:
-      #     credentials: ${{ secrets.GOOGLE_DRIVE_TOKEN }}
-      #     filename: android/android/app/build/outputs/apk/release/app-release.apk
-      #     folderId: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
-      #     overwrite: "true"
+      - name: Create variables
+        id: variables
+        run: |
+          date_string="$(date +'%Y-%m-%dT-%H-%M-%S')"
+          echo "date_string=$date_string" >> $GITHUB_OUTPUT
+
+      - name: Upload to Google Drive
+        uses: adityak74/google-drive-upload-git-action@main
+        with:
+          credentials: ${{ secrets.GOOGLE_DRIVE_TOKEN }}
+          folderId: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+          name: "app-release-${{ steps.variables.outputs.date_string }}.apk"
+          filename: ${{ env.REPO_RELPATH }}/${{ env.APP_RELPATH }}/${{ env.APK_RELEASE_DIR_RELPATH }}/${{ env.APK_RELEASE_FILENAME }}
+          overwrite: "false"
 
       - name: Builds as artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -1,15 +1,19 @@
 name: Build Web Server
 
 on:
-  push:
-    tags:
-      - "**.**.**"
-      - "experiment/**/**/**"
-    paths:
-      - apps/**
-      - packages/**
-      - .github/workflows/build-web.yml
+  # push:
+  #   tags:
+  #     - "**.**.**"
+  #     - "experiment/**/**/**"
+  #   paths:
+  #     - apps/**
+  #     - packages/**
+  #     - .github/workflows/build-web.yml
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CONTAINER_NAME: web-server-nextjsgprc-projects-utkusarioglu-com
@@ -41,12 +45,12 @@ jobs:
           fetch-depth: 2
           path: ${{ matrix.images.repoRelPath }} 
 
-      # - name: Checkout proto
-      #   uses: actions/checkout@v3
-      #   with:
-      #     repository: utkusarioglu/nextjs-grpc-proto
-      #     fetch-depth: 2
-      #     path: proto 
+      - name: Checkout proto
+        uses: actions/checkout@v3
+        with:
+          repository: utkusarioglu/nextjs-grpc-proto
+          fetch-depth: 2
+          path: proto 
 
       - name: Get changed files
         id: changed_files
@@ -58,12 +62,14 @@ jobs:
             ${{ matrix.images.readmeFile }}
             ${{ matrix.images.additionalFilesToWatch }}
             .github/workflows/build-web.yml
-            ./apps/**
-            ./packages/**
+            ./apps/**/*
+            ./packages/**/*
 
       - name: Declare run state
         id: run_state
         run: |
+          echo "All modified files list:"
+          echo "${{ steps.changed_files.outputs.all_modified_files }}"
           if [ ${{ github.ref_type }} == tag ] && ( \
             [ ${{ steps.changed_files.outputs.any_modified }} == true ] || \
             [ ${{ github.event_name }} == workflow_dispatch ] \
@@ -105,7 +111,7 @@ jobs:
 
       - name: Login to DockerHub
         if: steps.run_state.outputs.run_docker_build == 'true'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/apps/android/src/App.tsx
+++ b/apps/android/src/App.tsx
@@ -12,7 +12,7 @@ import { RootNavigation } from "./RootNavigation";
 
 const linking = {
   prefixes: [
-    "http://localhost:3000",
+    "https://nextjs-grpc.utkusarioglu.com",
     //   // ...add your URLs here
     //   Linking.createURL('/'),
   ],

--- a/apps/web/.docker/Dockerfile.dev
+++ b/apps/web/.docker/Dockerfile.dev
@@ -34,7 +34,7 @@ ARG APP_ABSPATH="$REPO_ABSPATH/$APP_RELPATH"
 
 WORKDIR $PROJECT_ROOT_ABSPATH
 COPY $REPO_REL_PATH $REPO_REL_PATH
-# COPY proto proto
+COPY proto proto
 RUN chown -R $CONTAINER_USERNAME:$CONTAINER_GROUP $PROJECT_ROOT_ABSPATH
 
 WORKDIR $REPO_ABSPATH
@@ -75,10 +75,9 @@ COPY --from=builder "$APP_ABSPATH/package.json" package.json
 COPY --from=builder "$APP_ABSPATH/next.config.js" next.config.js
 RUN ls -al $APP_ABSPATH
 
-# WORKDIR  $PROJECT_ROOT/proto
-# COPY --from=builder $PROJECT_ROOT/proto/src src
-# RUN rm -rf src/defunct
-
+WORKDIR $PROJECT_ROOT_ABSPATH/proto
+COPY --from=builder $PROJECT_ROOT_ABSPATH/proto/src src
+RUN rm -rf src/defunct
 
 WORKDIR $APP_ABSPATH
 RUN yarn workspaces focus --production

--- a/apps/web/.helm/Chart.yaml
+++ b/apps/web/.helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: web-server
 description: Web server container for the nextjs-grpc workshop
 type: application
-version: 0.0.1
-appVersion: experiment-feat-build-web-25
+version: 0.0.1-6
+appVersion: experiment-feat-github-integration-23

--- a/apps/web/.helm/values.yaml
+++ b/apps/web/.helm/values.yaml
@@ -78,7 +78,7 @@ env:
   PROJECT_ROOT_ABSPATH: /utkusarioglu-com/projects/nextjs-grpc
   REPO_RELPATH: frontend
   APP_RELPATH: apps/web
-  # REPO_PROTOS_RELPATH: proto/src
+  REPO_PROTOS_RELPATH: proto/src
 
   MS_HOST: ms.ms
   MS_PORT: 50051
@@ -98,7 +98,7 @@ env:
   WEB_SERVER_SERVER_CERT_RELPATH: web-server-server-cert
 
   NEXT_PUBLIC_DOMAIN_NAME: <TF_POPULATED>
-  SCHEME: <TF_POPULATED>
+  NEXT_PUBLIC_SCHEME: <TF_POPULATED>
 
 cloudProvider:
   isLocal: false

--- a/apps/web/scripts/ca-certificates.sh
+++ b/apps/web/scripts/ca-certificates.sh
@@ -7,7 +7,8 @@
 #    registered.
 #
 
-source .env.local
+# TODO check if this resolves the "not found error in prod"
+source .env.local 2> /dev/null
 
 ms_grpc_client_cert_relpath="$CERTIFICATES_ABSPATH/$MS_GRPC_CLIENT_CERT_FOR_WEB_SERVER_RELPATH"
 

--- a/apps/web/src/pages/api/decade-stats.ts
+++ b/apps/web/src/pages/api/decade-stats.ts
@@ -1,0 +1,25 @@
+import { inflationApi } from "app/src/api/decade-stats";
+import { type NextApiHandler } from "next";
+
+const handler: NextApiHandler = async (req, res) => {
+  switch (req.method) {
+    case "GET":
+      const searchParamsStr = req.url.split("?")[1] || "";
+      const searchParams = new URLSearchParams(searchParamsStr);
+      const codes = searchParams.get("codes")?.split(",");
+      if (!codes || !codes.length) {
+        res.status(500);
+        throw new Error("NO_CODES_GIVEN");
+      }
+      const codesSanitized = codes.map((code) => code.toUpperCase());
+      const response = await inflationApi(codesSanitized);
+      console.log({ codes, codesSanitized, response });
+      res.status(200).json(response);
+      break;
+
+    default:
+      res.status(501);
+  }
+};
+
+export default handler;

--- a/apps/web/src/pages/api/inflation.ts
+++ b/apps/web/src/pages/api/inflation.ts
@@ -1,7 +1,0 @@
-import { inflationApi } from "app/src/api/inflation";
-
-export default async function handler(_req, res) {
-  const codes = ["TUR", "FRA", "USA"];
-  const response = await inflationApi(codes);
-  res.status(200).json(response);
-}

--- a/packages/app/.gitignore
+++ b/packages/app/.gitignore
@@ -1,0 +1,1 @@
+artifacts

--- a/packages/app/babel.config.js
+++ b/packages/app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    "@babel/preset-typescript",
+  ],
+};

--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -1,0 +1,195 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/tmp/jest_rs",
+
+  // Automatically clear mock calls, instances, contexts and results before every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  collectCoverage: true,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: "artifacts/coverage",
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // Indicates which provider should be used to instrument code for coverage
+  coverageProvider: "v8",
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // The default configuration for fake timers
+  // fakeTimers: {
+  //   "enableGlobally": false
+  // },
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: undefined,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: undefined,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: undefined,
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state before every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state and implementation before every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
+
+  // The number of seconds after which a test is considered as slow and reported as such in the results.
+  // slowTestThreshold: 5,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  // testEnvironment: "jest-environment-node",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  // testMatch: [
+  //   "**/__tests__/**/*.[jt]s?(x)",
+  //   "**/?(*.)+(spec|test).[tj]s?(x)"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jest-circus/runner",
+
+  // A map from regular expressions to paths to transformers
+  // transform: undefined,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/",
+  //   "\\.pnp\\.[^\\/]+$"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,5 +6,13 @@
   "dependencies": {
     "solito": "^3.2.6",
     "ui": "*"
+  },
+  "devDependencies": {
+    "@babel/preset-typescript": "^7.21.5",
+    "@jest/globals": "^29.5.0",
+    "jest": "^29.5.0"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/packages/app/src/api/decade-stats.ts
+++ b/packages/app/src/api/decade-stats.ts
@@ -1,0 +1,14 @@
+import { InflationService } from "../services/inflation";
+import { getTlsProps } from "../utils/readCertPath";
+
+export const tlsProps = getTlsProps();
+
+export async function inflationApi(codes: string[]) {
+  try {
+    const inflationService = new InflationService(tlsProps);
+    const response = await inflationService.decadeStats(codes);
+    return { decadeStats: response };
+  } catch (e: any) {
+    return { decadeStats: [], error: e.toString() };
+  }
+}

--- a/packages/app/src/api/decade-stats.unit.test.ts
+++ b/packages/app/src/api/decade-stats.unit.test.ts
@@ -1,0 +1,18 @@
+import { readCertPath } from "../utils/readCertPath";
+
+process.env = {
+  ...process.env,
+  CERTIFICATES_ABSPATH:
+    "/utkusarioglu-com/projects/nextjs-grpc/frontend/apps/web/.certs",
+  MS_GRPC_CLIENT_CERT_FOR_WEB_SERVER_RELPATH:
+    "ms-grpc-client-cert-for-web-server",
+  WEB_SERVER_SERVER_CERT_RELPATH: "web-server-server-cert",
+};
+
+describe("decade-stats", () => {
+  it("readCertPath", () => {
+    const response = readCertPath("ca.crt");
+    expect(Buffer.isBuffer(response)).toBe(true);
+    expect(response.length).toBeGreaterThan(2);
+  });
+});

--- a/packages/app/src/screens/DecadeStats.screen.tsx
+++ b/packages/app/src/screens/DecadeStats.screen.tsx
@@ -1,30 +1,94 @@
 import { useEffect, useState } from "react";
 import { YStack, Text, DecadeStatsCardView } from "ui";
 
-const URL = "https://nextjs-grpc.utkusarioglu.com/api/inflation";
+const URL = "https://nextjs-grpc.utkusarioglu.com";
+const url = [
+  // process.env.NEXT_PUBLIC_SCHEME,
+  // "://",
+  // process.env.NEXT_PUBLIC_DOMAIN_NAME,
+  URL,
+  "/api/decade-stats",
+  "?codes=TUR",
+].join("");
+
+interface DecadeStatsApiResponse {
+  decadeStats: any[];
+}
+
+type DecadeStatsState = DecadeStatsApiResponse & {
+  time: number;
+  error: boolean;
+};
+
+const DECADE_STATS_INITIAL: DecadeStatsState = {
+  decadeStats: [],
+  time: 0,
+  error: false,
+};
 
 const DecadeStatsScreen = () => {
-  const [list, setList] = useState<any[]>([]);
+  const [list, setList] = useState<DecadeStatsState>(DECADE_STATS_INITIAL);
   useEffect(() => {
-    fetch(URL)
+    fetch(url)
       .then((res) => res.json())
-      .then((response) => setList(response))
-      .catch((e) => console.log(e));
+      .then((res) => {
+        if (res.error) {
+          console.log({ serverError: res.error });
+          setList({
+            ...DECADE_STATS_INITIAL,
+            time: Date.now(),
+            error: true,
+          });
+          return;
+        }
+        setList({
+          ...DECADE_STATS_INITIAL,
+          decadeStats: res.decadeStats,
+          time: Date.now(),
+        });
+      })
+      .catch((e) => {
+        console.log({ e });
+        setList({
+          ...DECADE_STATS_INITIAL,
+          error: true,
+        });
+      });
   }, []);
 
-  if (!list.length) {
+  if (list.error) {
     return (
       <YStack>
-        <Text>{URL}</Text>
+        <Text>{url}</Text>
+        <Text>There was an error, try again</Text>
+      </YStack>
+    );
+  }
+
+  if (!list.time) {
+    return (
+      <YStack>
+        <Text>{url}</Text>
         <Text>Loading...</Text>
+      </YStack>
+    );
+  }
+
+  if (!list.decadeStats.length) {
+    return (
+      <YStack>
+        <Text>{url}</Text>
+        <Text>{new Date(list.time).toLocaleDateString()}</Text>
+        <Text>The list is empty</Text>
       </YStack>
     );
   }
 
   return (
     <YStack>
-      <Text>{URL}</Text>
-      {list.map((item) => (
+      <Text>{url}</Text>
+      <Text>{new Date(list.time).toLocaleDateString()}</Text>
+      {list.decadeStats.map((item) => (
         <DecadeStatsCardView key={item.countryCode} item={item} />
       ))}
     </YStack>

--- a/packages/app/src/screens/Home.screen.tsx
+++ b/packages/app/src/screens/Home.screen.tsx
@@ -8,7 +8,7 @@ const HomeScreen = () => {
   const { push } = useRouter();
   return (
     <YStack>
-      <CustomHeader>Hi Hello Howdy</CustomHeader>
+      <CustomHeader>Hi Hello Howdy!</CustomHeader>
       <CustomInput />
       <Spacer />
       <XStack>

--- a/packages/app/src/services/inflation.ts
+++ b/packages/app/src/services/inflation.ts
@@ -64,7 +64,7 @@ export class InflationService {
         const rows: any[] = [];
         const call = this.service.decadeStats({ codes });
         // TODO you need a way for types to be created from protos
-        // @ts-expect-error
+        // @ts-ignore
         call.on("data", (row) => {
           rows.push(row);
         });
@@ -72,7 +72,7 @@ export class InflationService {
           resolve(rows);
         });
         // TODO typing
-        // @ts-expect-error
+        // @ts-ignore
         call.on("error", (error) => {
           console.log({ error });
           reject("GRPC_ERROR");

--- a/packages/app/src/utils/readCertPath.ts
+++ b/packages/app/src/utils/readCertPath.ts
@@ -1,8 +1,7 @@
-import { InflationService } from "../services/inflation";
 import { readFileSync } from "fs";
 import path from "path";
 
-const readCertPath = (filename: string): Buffer => {
+export const readCertPath = (filename: string): Buffer => {
   const certsPath = process.env.CERTIFICATES_ABSPATH!;
   const msGrpcClientCertForWebServer =
     process.env.MS_GRPC_CLIENT_CERT_FOR_WEB_SERVER_RELPATH!;
@@ -11,14 +10,9 @@ const readCertPath = (filename: string): Buffer => {
   );
   return certPath;
 };
-const tlsProps = {
+
+export const getTlsProps = () => ({
   caCrt: readCertPath("ca.crt"),
   tlsCrt: readCertPath("tls.crt"),
-  tlsKey: readCertPath("tls.key"), // TODO fix this
-};
-
-export async function inflationApi(codes: string[]) {
-  const inflationService = new InflationService(tlsProps);
-  const response = await inflationService.decadeStats(codes);
-  return response;
-}
+  tlsKey: readCertPath("tls.key"),
+});

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "tsconfig/react-library.json",
   "compilerOptions": {
     "composite": true,
+    "isolatedModules": false,
     // "module": "ESNext",
     // "target": "ESNext",
     "jsx": "react-jsx",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,7 +1443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.13.0":
+"@babel/preset-typescript@npm:^7.13.0, @babel/preset-typescript@npm:^7.21.5":
   version: 7.21.5
   resolution: "@babel/preset-typescript@npm:7.21.5"
   dependencies:
@@ -6109,6 +6109,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:packages/app"
   dependencies:
+    "@babel/preset-typescript": ^7.21.5
+    "@jest/globals": ^29.5.0
+    jest: ^29.5.0
     solito: ^3.2.6
     ui: "*"
   languageName: unknown
@@ -10927,7 +10930,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.2.1":
+"jest@npm:^29.2.1, jest@npm:^29.5.0":
   version: 29.5.0
   resolution: "jest@npm:29.5.0"
   dependencies:


### PR DESCRIPTION
- Update `build-android` and `build-web` workflows.
- Introduce testing in some packages in guidance of the CI failures.
  This is just a starter and more tests are definitely needed throughout
  the repo. These tests are only being committed because they were
  instrumental for getting CI to work right.
- Minor changes in the app that are only introduced for the sake of CI,
  they aren't consequential.
- Alter helm chart versions, no major or minor change happened.
- Update `dockerfile.dev` to consume `proto` repo. This was a
  requirement that was turned off during the initiation of the project.
  It was required to be turned off for the repo's integration for CI.
