### PR TITLE
Chore: Update devcontainer version

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,8 +2,7 @@ version: "3.9"
 
 services:
   nextjs-grpc-frontend:
-    # image: utkusarioglu/react-native-android-devcontainer:1.0.17
-    image: utkusarioglu/react-native-android-devcontainer:tag-unavailable
+    image: utkusarioglu/react-native-android-devcontainer:1.0.18
     environment:
       ANDROID_TARGET_DEVICE: android-host:58526
     extra_hosts:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -29,9 +29,9 @@ jobs:
       NEXT_PUBLIC_WEB_APP_URL: ${{ secrets.NEXT_PUBLIC_WEB_APP_URL }}
       NEXT_PUBLIC_API_V1_URL: ${{ secrets.NEXT_PUBLIC_API_V1_URL }}
     container:
-      image: utkusarioglu/react-native-android-devcontainer:tag-unavailable
+      image: utkusarioglu/react-native-android-devcontainer:1.0.18
       options: --user=0:0
-      # image: utkusarioglu/react-native-android-devcontainer:1.0.17
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -37,6 +37,13 @@ jobs:
             dockerfile: .docker/Dockerfile.dev
             additionalFilesToWatch: ""
             readmeFile: .docker/DOCKER_README.md
+    env:
+      NODE_ENV: production
+      NEXT_PUBLIC_WEB_APP_URL: ${{ secrets.NEXT_PUBLIC_WEB_APP_URL }}
+      NEXT_PUBLIC_API_V1_URL: ${{ secrets.NEXT_PUBLIC_API_V1_URL }}
+    container:
+      image: utkusarioglu/react-native-android-devcontainer:1.0.18
+      options: --user=0:0
 
     steps:
       - name: Checkout ${{ matrix.images.repoRelPath }}

--- a/scripts/post-create-command.sh
+++ b/scripts/post-create-command.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 yarn
+
+/home/rn/elam/elam.sh repo status


### PR DESCRIPTION
- Update devcontainer version to 1.0.18. New image includes newer
  versions of some of the tools, such as nvim. It also embeds elam
  inside the devcontainer.
- Add `elam repo status` to `post-create-command.sh`.
- Update `build-web` and `build-android` gh workflows to use the new
  image.
