### PR TITLE
Feat: Login form and related state logic

### DIFF
--- a/apps/android/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/android/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config>
-        <trust-anchors>
-            <certificates src="@raw/extracas"/>
-            <certificates src="system" />
-        </trust-anchors>
-    </base-config>
+  <domain-config>
+    <domain includeSubdomains="true">nextjs-grpc.utkusarioglu.com</domain>
+    <trust-anchors>
+      <certificates src="@raw/extracas"/>
+      <certificates src="system" />
+    </trust-anchors>
+  </domain-config>
+
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">127.0.0.1</domain>
+    <domain includeSubdomains="true">10.0.0.1</domain>
+    <domain includeSubdomains="true">localhost</domain>
+  </domain-config>
 </network-security-config>

--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "build-release": "cd android && ./gradlew assembleRelease",
     "adb-connect": "adb connect $ANDROID_TARGET_DEVICE",
-    "rn-start": "TAMAGUI_TARGET=native react-native start --reset-cache",
+    "rn-start": "TAMAGUI_TARGET=native react-native start",
     "rn-android": "TAMAGUI_TARGET=native react-native run-android --no-packager --active-arch-only",
     "dev": "yarn adb-connect && yarn rn-start & yarn rn-android",
+    "dev:no-telemetry": "yarn dev",
     "lint": "eslint .",
     "test": "jest"
   },
@@ -18,6 +19,7 @@
     "react": "18.2.0",
     "react-native": "0.71.8",
     "react-native-dotenv": "^3.4.8",
+    "react-native-encrypted-storage": "^4.0.3",
     "react-native-gesture-handler": "^2.10.0",
     "react-native-safe-area-context": "^4.5.2",
     "react-native-screens": "^3.20.0",

--- a/apps/android/src/App.tsx
+++ b/apps/android/src/App.tsx
@@ -1,29 +1,11 @@
 import UiProvider from "ui/src/Provider";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import tamaguiConfig from "../tamagui.config";
-import { useColorScheme } from "react-native";
-import { NavigationContainer } from "@react-navigation/native";
-import {
-  DarkTheme as ReactNavigationDarkTheme,
-  DefaultTheme as ReactNavigationDefaultTheme,
-} from "@react-navigation/native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { RootNavigation } from "./RootNavigation";
 import { StoreProvider } from "store/src/index";
-
-console.log({ env: process.env, webApp: process.env.NEXT_PUBLIC_WEB_APP_URL });
-
-const linking = {
-  prefixes: [process.env.NEXT_PUBLIC_WEB_APP_URL!],
-  config: {
-    initialRouteName: "home" as "home",
-    screens: {
-      home: "",
-      user: "user/:userId",
-      decadeStats: "decade-stats",
-    },
-  },
-};
+import { useColorScheme } from "react-native";
+import EncryptedStorage from "react-native-encrypted-storage";
 
 const App = () => {
   const colorScheme = useColorScheme();
@@ -31,22 +13,19 @@ const App = () => {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <StoreProvider>
+        <StoreProvider
+          storageAssignments={{
+            authSlice: EncryptedStorage,
+            decadeStatsSlice: EncryptedStorage,
+          }}
+          loadingViewComponent={null}>
           <UiProvider
             config={tamaguiConfig}
             // @ts-ignore
             disableInjectCSS
             defaultTheme={colorScheme}
             disableRootThemeClass>
-            <NavigationContainer
-              linking={linking}
-              theme={
-                colorScheme === "dark"
-                  ? ReactNavigationDarkTheme
-                  : ReactNavigationDefaultTheme
-              }>
-              <RootNavigation />
-            </NavigationContainer>
+            <RootNavigation />
           </UiProvider>
         </StoreProvider>
       </SafeAreaProvider>

--- a/apps/android/src/RootNavigation.tsx
+++ b/apps/android/src/RootNavigation.tsx
@@ -1,7 +1,29 @@
 import HomeScreen from "app/src/screens/Home.screen";
 import UserScreen from "app/src/screens/User.screen";
 import DecadeStatsScreen from "app/src/screens/DecadeStats.screen";
+import LoginScreen from "app/src/screens/Login.screen";
+import LogoutScreen from "app/src/screens/Logout.screen";
+import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { selectLoggedIn, useLoginMutation, useSelector } from "store/src";
+import { useColorScheme } from "react-native";
+import {
+  DarkTheme as ReactNavigationDarkTheme,
+  DefaultTheme as ReactNavigationDefaultTheme,
+} from "@react-navigation/native";
+
+const linking = {
+  prefixes: [process.env.NEXT_PUBLIC_WEB_APP_URL!],
+  config: {
+    screens: {
+      home: "",
+      user: "user/:userId",
+      decadeStats: "decade-stats",
+      login: "login",
+      logout: "logout",
+    },
+  },
+};
 
 const Stack = createNativeStackNavigator<{
   home: undefined;
@@ -9,32 +31,66 @@ const Stack = createNativeStackNavigator<{
     userId: string;
   };
   decadeStats: undefined;
+  login: undefined;
+  logout: undefined;
 }>();
 
 export function RootNavigation() {
+  const colorScheme = useColorScheme();
+  const loggedIn = useSelector(selectLoggedIn);
+
   return (
-    <Stack.Navigator>
-      <Stack.Screen
-        name="home"
-        component={HomeScreen}
-        options={{
-          title: "Home",
-        }}
-      />
-      <Stack.Screen
-        name="user"
-        component={UserScreen}
-        options={{
-          title: "User",
-        }}
-      />
-      <Stack.Screen
-        name="decadeStats"
-        component={DecadeStatsScreen}
-        options={{
-          title: "Decade Stats",
-        }}
-      />
-    </Stack.Navigator>
+    <NavigationContainer
+      linking={linking}
+      theme={
+        colorScheme === "dark"
+          ? ReactNavigationDarkTheme
+          : ReactNavigationDefaultTheme
+      }>
+      <Stack.Navigator>
+        {loggedIn ? (
+          <>
+            <Stack.Screen
+              name="home"
+              component={HomeScreen}
+              options={{
+                title: "Home",
+              }}
+            />
+            <Stack.Screen
+              name="user"
+              component={UserScreen}
+              options={{
+                title: "User",
+              }}
+            />
+            <Stack.Screen
+              name="decadeStats"
+              component={DecadeStatsScreen}
+              options={{
+                title: "Decade Stats",
+              }}
+            />
+            <Stack.Screen
+              name="logout"
+              component={LogoutScreen}
+              options={{
+                title: "Logout",
+              }}
+            />
+          </>
+        ) : (
+          <>
+            <Stack.Screen
+              name="login"
+              component={LoginScreen}
+              options={{
+                title: "Login",
+              }}
+            />
+          </>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "0.71.8",
+    "redux-persist": "^6.0.0",
     "store": "*",
     "ui": "*"
   },

--- a/apps/web/scripts/dev-no-telemetry.sh
+++ b/apps/web/scripts/dev-no-telemetry.sh
@@ -4,4 +4,4 @@ echo "Starting dev without telemetry…"
 
 source scripts/ca-certificates.sh
 
-AAA=bbb ENABLE_INSTRUMENTATION=FALSE TAMAGUI_TARGET=web yarn next dev
+ENABLE_INSTRUMENTATION=FALSE TAMAGUI_TARGET=web yarn next dev

--- a/apps/web/src/components/providers/ClientSideRouteGuard.provider.tsx
+++ b/apps/web/src/components/providers/ClientSideRouteGuard.provider.tsx
@@ -1,0 +1,44 @@
+import { useEffect, type FC, type ReactNode } from "react";
+import { selectProfile, useSelector } from "store/src";
+import { useRouter } from "solito/router";
+import { GUEST_PATHS } from "../../constants";
+
+interface ClientSideRouteGuardProviderProps {
+  children: ReactNode;
+}
+
+const ClientSideRouteGuardProvider: FC<ClientSideRouteGuardProviderProps> = ({
+  children,
+}) => {
+  const {
+    authId,
+    username,
+    _persist: { rehydrated },
+  } = useSelector(selectProfile);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (window) {
+      const pathname = window.location.pathname;
+      const isGuest = !authId && !username;
+      // const hasPotentialSession = authId && !username;
+      const isLoggedIn = !!authId && !!username;
+      const onGuestPath = GUEST_PATHS.includes(pathname);
+
+      if (rehydrated) {
+        if (isLoggedIn && onGuestPath) {
+          router.push("/");
+        } else if (isGuest && !onGuestPath) {
+          console.log("Redirecting to login");
+          router.push("/login");
+        }
+      }
+    } else {
+      console.log("no window", authId, username);
+    }
+  }, [authId, username, router, rehydrated]);
+
+  return <>{children}</>;
+};
+
+export default ClientSideRouteGuardProvider;

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -1,0 +1,2 @@
+export const GUEST_PATHS = ["/login", "/welcome"];
+export const SYSTEM_PATHS = ["/api", "/_next"];

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,33 +1,45 @@
 import { NextThemeProvider, useRootTheme } from "@tamagui/next-theme";
 import { AppProps } from "next/app";
-// import Head from "next/head";
 import React, { useMemo } from "react";
 import UiProvider from "ui/src/Provider";
 import { StoreProvider } from "store/src/index";
-
 import tamaguiConfig from "../tamagui.config";
+import ClientSideRouteGuardProvider from "../components/providers/ClientSideRouteGuard.provider";
+import localStorage from "redux-persist/lib/storage";
+import { cookieStorage } from "src/utils/cookie.utils";
 
+/**
+ * @dev
+ * #1 memo to avoid re-render on dark/light change
+ * #2 because we do our custom getCSS() above, we disableInjectCSS here
+ */
 export default function App({ Component, pageProps }: AppProps) {
   const [theme, setTheme] = useRootTheme();
-
-  // memo to avoid re-render on dark/light change
   const contents = useMemo(() => {
+    // #1
     return <Component {...pageProps} />;
   }, [pageProps, Component]);
 
-  // because we do our custom getCSS() above, we disableInjectCSS here
   return (
-    <StoreProvider>
+    <StoreProvider
+      storageAssignments={{
+        authSlice: cookieStorage,
+        decadeStatsSlice: localStorage,
+      }}
+      loadingViewComponent={null}
+    >
       {/* @ts-ignore */}
       <NextThemeProvider onChangeTheme={setTheme}>
         <UiProvider
           config={tamaguiConfig}
           // @ts-ignore
-          disableInjectCSS
+          disableInjectCSS // #2
           disableRootThemeClass
           defaultTheme={theme}
         >
-          {contents}
+          <ClientSideRouteGuardProvider>
+            {contents}
+          </ClientSideRouteGuardProvider>
         </UiProvider>
       </NextThemeProvider>
     </StoreProvider>

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,3 +1,8 @@
 import HomeScreen from "app/src/screens/Home.screen";
+import { routeProtector } from "src/utils/route.util";
+
+export const getServerSideProps = async ({ req, _res }) => {
+  return routeProtector(req);
+};
 
 export default HomeScreen;

--- a/apps/web/src/pages/login/index.tsx
+++ b/apps/web/src/pages/login/index.tsx
@@ -1,8 +1,8 @@
-import DecadeStatsScreen from "app/src/screens/DecadeStats.screen";
+import LoginScreen from "app/src/screens/Login.screen";
 import { routeProtector } from "src/utils/route.util";
 
 export const getServerSideProps = async ({ req, _res }) => {
   return routeProtector(req);
 };
 
-export default DecadeStatsScreen;
+export default LoginScreen;

--- a/apps/web/src/pages/logout/index.tsx
+++ b/apps/web/src/pages/logout/index.tsx
@@ -1,8 +1,8 @@
-import DecadeStatsScreen from "app/src/screens/DecadeStats.screen";
+import LogoutScreen from "app/src/screens/Logout.screen";
 import { routeProtector } from "src/utils/route.util";
 
 export const getServerSideProps = async ({ req, _res }) => {
   return routeProtector(req);
 };
 
-export default DecadeStatsScreen;
+export default LogoutScreen;

--- a/apps/web/src/utils/cookie.utils.ts
+++ b/apps/web/src/utils/cookie.utils.ts
@@ -1,0 +1,37 @@
+export function parseCookies(cookie: string) {
+  return cookie.split(";").reduce((p, c) => {
+    const [keyDirty, valueDirty] = c.split("=");
+    if (!valueDirty) {
+      return p;
+    }
+    p[keyDirty.trim()] = valueDirty.trim();
+    return p;
+  }, {} as Record<string, string>);
+}
+
+export const cookieStorage = {
+  getItem(itemName: string) {
+    if (!global.window) {
+      return Promise.resolve();
+    }
+    const cookies = parseCookies(document.cookie);
+    if (!cookies || !cookies[itemName]) {
+      return Promise.resolve();
+    }
+    return Promise.resolve(cookies[itemName]);
+  },
+  setItem(itemName: string, itemValue: string) {
+    if (!global.window) {
+      return Promise.resolve();
+    }
+    document.cookie = `${itemName}=${itemValue}`;
+    return Promise.resolve();
+  },
+  removeItem(itemName: string) {
+    if (!global.document) {
+      return Promise.resolve();
+    }
+    document.cookie = `${itemName}=''`;
+    return Promise.resolve();
+  },
+};

--- a/apps/web/src/utils/route.util.ts
+++ b/apps/web/src/utils/route.util.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from "next/server";
+import { GUEST_PATHS, SYSTEM_PATHS } from "../constants";
+
+// const SAFE_PATHS_FOR_GUESTS = ["/", "/logout"];
+interface Auth {
+  authId: string;
+  username: string;
+  _persist: string;
+}
+
+async function validateSession(auth: Auth): Promise<boolean> {
+  const { authId } = auth;
+  return Promise.resolve(authId === "guest");
+}
+
+export async function routeProtector(req: NextRequest) {
+  const onGuestPath = GUEST_PATHS.includes(req.url);
+  const onLoginPage = req.url === "/login";
+  const onSystemPath = SYSTEM_PATHS.some((path) => req.url.startsWith(path));
+
+  try {
+    const sessionSliceString = req.cookies["persist:profileSlice"];
+    if (!sessionSliceString) {
+      return {
+        props: {},
+      };
+    }
+    const session = JSON.parse(sessionSliceString.replace(/\\"/g, ""));
+    const hasValidSession = await validateSession(session);
+
+    if (onGuestPath && hasValidSession) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: "/",
+        },
+      };
+    } else if (!onGuestPath && !onSystemPath && !hasValidSession) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: "/login",
+        },
+      };
+    }
+  } catch (e) {
+    // TODO remove this
+    console.log("something failed", e);
+    if (!onLoginPage) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: "/login",
+        },
+      };
+    }
+    return {
+      props: {},
+    };
+  }
+
+  return {
+    props: {},
+  };
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,6 +4,7 @@
   "main": "./src/index.tsx",
   "types": "./src/index.tsx",
   "dependencies": {
+    "formik": "^2.4.0",
     "solito": "^3.2.6",
     "store": "*",
     "ui": "*"
@@ -12,6 +13,9 @@
     "@babel/preset-typescript": "^7.21.5",
     "@jest/globals": "^29.5.0",
     "jest": "^29.5.0"
+  },
+  "peerDependencies": {
+    "react": "*"
   },
   "scripts": {
     "test": "jest"

--- a/packages/app/src/hooks/auth.hooks.ts
+++ b/packages/app/src/hooks/auth.hooks.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { useFormik } from "formik";
+import {
+  useLogoutMutation,
+  useDispatch,
+  setAuth,
+  authInitialState,
+  useLoginWithUserPassMutation,
+} from "store/src";
+
+export function useLogin() {
+  const dispatch = useDispatch();
+  const [loginWithUserPass, { isLoading, data }] =
+    useLoginWithUserPassMutation();
+  const formik = useFormik({
+    initialValues: {
+      username: "",
+      password: "",
+      rememberMe: false,
+    },
+    onSubmit: async ({ username, password }, { setSubmitting }) => {
+      setSubmitting(true);
+      await loginWithUserPass({ username, password }).unwrap();
+      if (!isLoading) {
+        setSubmitting(false);
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (data && data.authId) {
+        dispatch(setAuth(data));
+      }
+    }
+  }, [isLoading, data?.authId]);
+
+  return { formik };
+}
+
+export function useLogout() {
+  const dispatch = useDispatch();
+  const [logout, { data, isLoading }] = useLogoutMutation();
+
+  useEffect(() => {
+    logout(null).unwrap();
+  }, []);
+
+  useEffect(() => {
+    if (!!data && !data.authId) {
+      console.log("dispatch firing", { data });
+      dispatch(setAuth(authInitialState));
+    }
+  }, [data?.authId]);
+
+  return { isLoading };
+}

--- a/packages/app/src/layouts/DecadeStatsCardList.layout.tsx
+++ b/packages/app/src/layouts/DecadeStatsCardList.layout.tsx
@@ -13,8 +13,9 @@ export const DecadeStatsCardListLayout: FC<
   const countryList = useSelector(selectCountryList);
   const countriesArray = countryList
     .split(",")
-    .map((i) => i.trim())
-    .filter((i) => !!i);
+    // TODO remove any
+    .map((i: any) => i.trim())
+    .filter((i: any) => !!i);
   const { data, error, isLoading } = useInflationDecadeStats(countriesArray);
 
   if (error) {

--- a/packages/app/src/screens/Home.screen.tsx
+++ b/packages/app/src/screens/Home.screen.tsx
@@ -8,7 +8,7 @@ const HomeScreen = () => {
   const { push } = useRouter();
 
   return (
-    <YStack>
+    <YStack padding="$4">
       <CustomHeader>Hi Hello Howdy!</CustomHeader>
       <CustomInput />
       <Spacer />
@@ -28,6 +28,16 @@ const HomeScreen = () => {
         }
       >
         Decade Stats
+      </Button>
+      <Spacer />
+      <Button
+        onPress={() =>
+          push({
+            pathname: "/logout",
+          })
+        }
+      >
+        Logout
       </Button>
     </YStack>
   );

--- a/packages/app/src/screens/Login.screen.tsx
+++ b/packages/app/src/screens/Login.screen.tsx
@@ -1,0 +1,72 @@
+import {
+  YStack,
+  Input,
+  Form,
+  Button,
+  Label,
+  Switch,
+  Spinner,
+  XStack,
+  Spacer,
+} from "ui";
+import { useLogin } from "../hooks/auth.hooks";
+
+const LoginScreen = () => {
+  const { formik } = useLogin();
+
+  return (
+    <YStack>
+      <Form padding="$4" onSubmit={formik.handleSubmit}>
+        <Label htmlFor="username">Username</Label>
+        <Input
+          id="username"
+          disabled={formik.isSubmitting}
+          autoCorrect={false}
+          onChangeText={formik.handleChange("username")}
+          value={formik.values.username}
+          inputMode="text"
+          textContentType="username"
+        />
+        <Label htmlFor="username">Password</Label>
+        <Input
+          id="password"
+          autoCorrect={false}
+          disabled={formik.isSubmitting}
+          onChangeText={formik.handleChange("password")}
+          value={formik.values.password}
+          secureTextEntry={true}
+          inputMode="text"
+          textContentType="password"
+        />
+        <Spacer />
+        <XStack>
+          <Label htmlFor="remember-me">Remember me</Label>
+          <Switch
+            id="remember-me"
+            disabled={formik.isSubmitting}
+            onCheckedChange={(rememberMe) =>
+              formik.setFieldValue("rememberMe", rememberMe)
+            }
+            checked={formik.values.rememberMe}
+          >
+            <Switch.Thumb animation="quick" />
+          </Switch>
+        </XStack>
+        <Spacer />
+        <Form.Trigger asChild>
+          <Button
+            // @ts-expect-error
+            // This prop doesn't exist for tamagui or rn-web
+            // but it's required by formik
+            type="submit"
+            icon={formik.isSubmitting ? () => <Spinner /> : undefined}
+          >
+            Login
+          </Button>
+        </Form.Trigger>
+      </Form>
+    </YStack>
+  );
+};
+
+export default LoginScreen;

--- a/packages/app/src/screens/Logout.screen.tsx
+++ b/packages/app/src/screens/Logout.screen.tsx
@@ -1,0 +1,20 @@
+import { Paragraph, YStack } from "ui";
+import { useLogout } from "../hooks/auth.hooks";
+
+const LogoutScreen = () => {
+  const { isLoading } = useLogout();
+
+  if (isLoading) {
+    <YStack padding="$4">
+      <Paragraph>Logging out...</Paragraph>
+    </YStack>;
+  }
+
+  return (
+    <YStack padding="$4">
+      <Paragraph>Redirecting...</Paragraph>
+    </YStack>
+  );
+};
+
+export default LogoutScreen;

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -6,7 +6,8 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "react-redux": "^8.0.5"
+    "react-redux": "^8.0.5",
+    "redux-persist": "^6.0.0"
   },
   "peerDependencies": {
     "react": "*"

--- a/packages/store/src/Provider.tsx
+++ b/packages/store/src/Provider.tsx
@@ -1,11 +1,25 @@
 import { type FC, type ReactNode } from "react";
 import { Provider } from "react-redux";
-import { store } from "./store";
+import { storeFactory, StorageAssignments } from "./store";
+import { PersistGate } from "redux-persist/integration/react";
 
 interface StoreProviderProps {
   children: ReactNode;
+  storageAssignments: StorageAssignments;
+  loadingViewComponent: ReactNode;
 }
 
-export const StoreProvider: FC<StoreProviderProps> = ({ children }) => {
-  return <Provider store={store}>{children}</Provider>;
+export const StoreProvider: FC<StoreProviderProps> = ({
+  children,
+  storageAssignments,
+  loadingViewComponent,
+}) => {
+  const { store, persistor } = storeFactory(storageAssignments);
+  return (
+    <Provider store={store}>
+      <PersistGate loading={loadingViewComponent} persistor={persistor}>
+        {children}
+      </PersistGate>
+    </Provider>
+  );
 };

--- a/packages/store/src/apis/auth.api.ts
+++ b/packages/store/src/apis/auth.api.ts
@@ -1,0 +1,50 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export interface LoginApiResponse {
+  authId: string;
+  username: string;
+}
+
+export interface LoginWithUserPassParams {
+  username: string;
+  password: string;
+}
+
+export interface LoginWithSessionIdParams {
+  authId: string;
+}
+
+export const authApi = createApi({
+  reducerPath: "authApi",
+  baseQuery: fetchBaseQuery({ baseUrl: process.env.NEXT_PUBLIC_API_V1_URL }),
+  endpoints: (builder) => ({
+    loginWithSessionId: builder.mutation<
+      LoginApiResponse,
+      LoginWithSessionIdParams
+    >({
+      query: (body) => ({
+        url: "auth/login/auth-id",
+        method: "POST",
+        body,
+      }),
+    }),
+    loginWithUserPass: builder.mutation<
+      LoginApiResponse,
+      LoginWithUserPassParams
+    >({
+      query: (body) => ({
+        url: "auth/login/user-pass",
+        method: "POST",
+        body,
+      }),
+    }),
+    logout: builder.mutation({
+      query: () => "auth/logout",
+    }),
+  }),
+});
+
+export const useLoginWithUserPassMutation =
+  authApi.useLoginWithUserPassMutation;
+
+export const useLogoutMutation = authApi.useLogoutMutation;

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,5 +1,16 @@
 export { StoreProvider } from "./Provider";
-export { store, type AppDispatch, type RootState } from "./store";
+export { type AppDispatch, type RootState } from "./store";
 export { useSelector, useDispatch } from "react-redux";
 export { selectCountryList, setCountries } from "./slices/decade-stats.slice";
+export {
+  selectLoggedIn,
+  setAuth,
+  selectProfile,
+  setAuthId,
+  initialState as authInitialState,
+} from "./slices/auth.slice";
 export { useInflationDecadeStats } from "./apis/inflation.api";
+export {
+  useLoginWithUserPassMutation,
+  useLogoutMutation,
+} from "./apis/auth.api";

--- a/packages/store/src/slices/auth.slice.ts
+++ b/packages/store/src/slices/auth.slice.ts
@@ -1,0 +1,41 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "../store";
+
+export interface AuthSlice {
+  authId: string;
+  username: string;
+}
+
+export const initialState: AuthSlice = {
+  authId: "",
+  username: "",
+};
+
+export const authSlice = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {
+    setAuth: (state, { payload }: PayloadAction<AuthSlice>) => {
+      return {
+        ...state,
+        ...payload,
+      };
+    },
+    setAuthId: (state, { payload }: PayloadAction<AuthSlice["authId"]>) => {
+      console.log("setting auth id", payload);
+      return {
+        ...state,
+        authId: payload,
+      };
+    },
+  },
+});
+
+const { actions, name } = authSlice;
+export const { setAuth, setAuthId } = actions;
+export default authSlice;
+
+export const selectLoggedIn = (state: RootState) => !!state[name].authId;
+
+export const selectProfile = (state: RootState) => state[name];

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,20 +1,81 @@
 import { configureStore } from "@reduxjs/toolkit";
+import {
+  persistStore,
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+  Persistor,
+} from "redux-persist";
 import { setupListeners } from "@reduxjs/toolkit/query/react";
 import decadeStatsSlice from "./slices/decade-stats.slice";
+import authSlice from "./slices/auth.slice";
+import { authApi } from "./apis/auth.api";
 import { inflationApi } from "./apis/inflation.api";
 
-export const store = configureStore({
-  reducer: {
-    [decadeStatsSlice.name]: decadeStatsSlice.reducer,
-    [inflationApi.reducerPath]: inflationApi.reducer,
-  },
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(inflationApi.middleware),
-});
+export interface StorageAssignments {
+  // TODO remove `any`
+  authSlice: any;
+  // TODO remove `any`
+  decadeStatsSlice: any;
+}
 
-// optional, but required for refetchOnFocus/refetchOnReconnect behaviors
-// see `setupListeners` docs - takes an optional callback as the 2nd arg for customization
-setupListeners(store.dispatch);
+interface StoreFactoryReturn {
+  persistor: Persistor;
+  // TODO remove `any`
+  store: any;
+}
 
-export type RootState = ReturnType<typeof store.getState>;
-export type AppDispatch = typeof store.dispatch;
+type StoreFactory = (s: StorageAssignments) => StoreFactoryReturn;
+
+export const storeFactory: StoreFactory = ({
+  authSlice: authSliceStorage,
+  decadeStatsSlice: decadeStatsSliceStorage,
+}) => {
+  const persistedAuthSliceReducer = persistReducer(
+    {
+      key: "profileSlice",
+      storage: authSliceStorage,
+    },
+    authSlice.reducer
+  );
+
+  const persistedDecadeStatsReducer = persistReducer(
+    {
+      key: "decadeStatsSlice",
+      storage: decadeStatsSliceStorage,
+    },
+    decadeStatsSlice.reducer
+  );
+
+  const store = configureStore({
+    reducer: {
+      [authSlice.name]: persistedAuthSliceReducer,
+      [decadeStatsSlice.name]: persistedDecadeStatsReducer,
+
+      [authApi.reducerPath]: authApi.reducer,
+      [inflationApi.reducerPath]: inflationApi.reducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: {
+          ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+        },
+      })
+        .concat(authApi.middleware)
+        .concat(inflationApi.middleware),
+  });
+
+  setupListeners(store.dispatch);
+
+  const persistor = persistStore(store);
+  return { store, persistor };
+};
+
+type Store = ReturnType<typeof storeFactory>["store"];
+
+export type RootState = ReturnType<Store["getState"]>;
+export type AppDispatch = Store["dispatch"];


### PR DESCRIPTION
In `packages/store`
- Add `authApi` and `authSlice` to ``store`.
- Define persistence logic in `store` using `redux-persist`.
- Add `redux-persist` as a dependency.
- Redesign the store `Provider` component to use persistence. This also
  involves the change in the api of the component. The change has been
  reflected in `web` and `android` apps.

In `scripts`:
- Update `start-mock-server.js` to respond to the new login form and
  other auth related endpoints.

In `packages/app`:
- Add `formik` as a new dependency. It is used for the login form for
  now, it will surely be used for a lot more in the future.
- Add `react` as a peer dependency. This was necessary as some react
  types are being consumed in this package.
- Define some `any` types in `DecadeStatsCardListLayoutProps`. These
  need to be rewritten in a future commit. TODOs were issued reminding
  the dev of the upcoming task.
- Add `LoginScreen` and `LogoutScreen` components for their respective
  features.
- Update `HomeScreen` by adding some padding and a logout button.
- Add new hooks in `auth.hook.ts` as a facade for login and logout operations.

In `apps/web`:
- Add `redux-persist` as a dependency. This is needed because the web
  storage offering from this library is used for `decadeStatsSlice`.
- Update `_app` to meet the requirements of the api change in
  `StoreProvider`.
- Create `ClientSideRouteGuardprovider` component for redirecting the
  client when a route replace is necessary, such as after login or
  logout or when the user somehow ends up on a route they aren't meant
  to visit in their current state.
- Add the component mentioned in previous item in `_app`.
- Add a server-side route guard in pages `login`, `logout`,
  `decade-stats`.
- Add a util module for cookies. This houses a cookie parsing function
  as well as a cookie storage option for `redux-persist`. This was
  required because the cookie storage driver for the library was very
  old and would have required far more work to get it working in a
  NextJS environment.
- Remove now irrelevant environment variable definition in
  `dev-no-telemetry.sh`.

In `apps/android`:
- Add `react-native-encrypted-storage` for persisting `authSlice`. Some
  storage option was required for `redux-persist` and this library was
  chosen after some research.
- Define `dev:no-telemetry` script in `package.json`. This makes it
  easier to run both web and android apps simultaneously by turbo.
- Add `network_security_config.xml` to allow self-signed CA to be used
  by the mock server. This configuration is incomplete as this CA is
  only required in testing and dev environments but the current config
  would push this CA to the prod as well. A future commit will need to
  address this issue.
- Refactor `App` and `RootNavigation` by moving the
  `NavigationContainer` component from `App` to `RootNavigation`. This
  was required because `NavigationContainer` now needs access to the
  state and this wouldn't have been possible in `App`.
- Add new routes in `RootNavigation` for login and logout.
- Update `RootNavigation` to consume logged in state to determine with
  stack to enque in `StackNavigator`
- Update `RootNavigation` to consume logged in state to determine with
  stack to enque in `StackNavigator`.
- Remove `initialRouteName` in stack navigator linking. This is done
  because the navigator is now dynamic and "home" is not always
  available.
