### PR TITLE
Feat: Welcome and Evm pages

### DIFF
--- a/apps/android/src/RootNavigation.tsx
+++ b/apps/android/src/RootNavigation.tsx
@@ -3,6 +3,8 @@ import UserScreen from "app/src/screens/User.screen";
 import DecadeStatsScreen from "app/src/screens/DecadeStats.screen";
 import LoginScreen from "app/src/screens/Login.screen";
 import LogoutScreen from "app/src/screens/Logout.screen";
+import WelcomeScreen from "app/src/screens/Welcome.screen";
+import EvmScreen from "app/src/screens/Evm.screen";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { selectLoggedIn, useSelector } from "store/src";
@@ -21,6 +23,8 @@ const linking = {
       decadeStats: "decade-stats",
       login: "login",
       logout: "logout",
+      welcome: "welcome",
+      evm: "evm",
     },
   },
 };
@@ -33,6 +37,8 @@ const Stack = createNativeStackNavigator<{
   decadeStats: undefined;
   login: undefined;
   logout: undefined;
+  welcome: undefined;
+  evm: undefined;
 }>();
 
 export function RootNavigation() {
@@ -47,7 +53,11 @@ export function RootNavigation() {
           ? ReactNavigationDarkTheme
           : ReactNavigationDefaultTheme
       }>
-      <Stack.Navigator>
+      <Stack.Navigator
+        screenOptions={{
+          headerShown: false,
+          animation: "fade",
+        }}>
         {loggedIn ? (
           <>
             <Stack.Screen
@@ -82,10 +92,24 @@ export function RootNavigation() {
         ) : (
           <>
             <Stack.Screen
+              name="welcome"
+              component={WelcomeScreen}
+              options={{
+                title: "Welcome",
+              }}
+            />
+            <Stack.Screen
               name="login"
               component={LoginScreen}
               options={{
                 title: "Login",
+              }}
+            />
+            <Stack.Screen
+              name="evm"
+              component={EvmScreen}
+              options={{
+                title: "Login with EVM identity",
               }}
             />
           </>

--- a/apps/android/tamagui.config.ts
+++ b/apps/android/tamagui.config.ts
@@ -1,3 +1,35 @@
-import config from "ui/src/tamagui.config";
+import { createAnimations } from "@tamagui/animations-css";
+import { createTamagui, baseConfig } from "ui/src/tamagui.config";
 
-export default config;
+const appConfig = createTamagui({
+  ...baseConfig,
+  animations: createAnimations({
+    fast: {
+      type: "spring",
+      damping: 20,
+      mass: 1.2,
+      stiffness: 250,
+    },
+    medium: {
+      type: "spring",
+      damping: 10,
+      mass: 0.9,
+      stiffness: 100,
+    },
+    slow: {
+      type: "spring",
+      damping: 20,
+      stiffness: 60,
+    },
+  }),
+});
+
+export type AppConfig = typeof appConfig;
+
+declare module "@tamagui/core" {
+  // overrides TamaguiCustomConfig so your custom types
+  // work everywhere you import `tamagui`
+  interface TamaguiCustomConfig extends AppConfig {}
+}
+
+export default appConfig;

--- a/apps/web/src/components/providers/ClientSideRouteGuard.provider.tsx
+++ b/apps/web/src/components/providers/ClientSideRouteGuard.provider.tsx
@@ -1,7 +1,7 @@
 import { useEffect, type FC, type ReactNode } from "react";
 import { selectProfile, useSelector } from "store/src";
 import { useRouter } from "solito/router";
-import { GUEST_PATHS } from "../../constants";
+import { GUEST_PATHS, GUEST_ENTRY_PATH } from "../../constants";
 
 interface ClientSideRouteGuardProviderProps {
   children: ReactNode;
@@ -28,7 +28,7 @@ const ClientSideRouteGuardProvider: FC<ClientSideRouteGuardProviderProps> = ({
         if (isLoggedIn && onGuestPath) {
           router.push("/");
         } else if (isGuest && !onGuestPath) {
-          router.push("/login");
+          router.push(GUEST_ENTRY_PATH);
         }
       }
     } else {

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -1,3 +1,4 @@
-export const GUEST_PATHS = ["/login", "/welcome"];
+export const GUEST_ENTRY_PATH = "/welcome";
+export const GUEST_PATHS = [GUEST_ENTRY_PATH, "/login", "/evm"];
 export const SYSTEM_PATHS = ["/api", "/_next"];
 export const AUTH_SLICE_COOKIE_NAME = "persist:authSlice";

--- a/apps/web/src/pages/_document.tsx
+++ b/apps/web/src/pages/_document.tsx
@@ -21,6 +21,14 @@ export default class Document extends NextDocument {
         key="tamagui"
         dangerouslySetInnerHTML={{ __html: tamaguiConfig.getCSS() }}
       />,
+      <style
+        key="web"
+        dangerouslySetInnerHTML={{
+          __html: `
+            html, body, #__next { height: 100%; }
+          `,
+        }}
+      />,
     ];
     return { ...page, styles: Children.toArray(styles) };
   }

--- a/apps/web/src/pages/evm/index.tsx
+++ b/apps/web/src/pages/evm/index.tsx
@@ -1,0 +1,8 @@
+import EvmScreen from "app/src/screens/Evm.screen";
+import { routeProtector } from "src/utils/route.util";
+
+export const getServerSideProps = async ({ req, _res }) => {
+  return routeProtector(req);
+};
+
+export default EvmScreen;

--- a/apps/web/src/pages/welcome/index.tsx
+++ b/apps/web/src/pages/welcome/index.tsx
@@ -1,0 +1,8 @@
+import WelcomeScreen from "app/src/screens/Welcome.screen";
+import { routeProtector } from "src/utils/route.util";
+
+export const getServerSideProps = async ({ req, _res }) => {
+  return routeProtector(req);
+};
+
+export default WelcomeScreen;

--- a/apps/web/src/tamagui.config.ts
+++ b/apps/web/src/tamagui.config.ts
@@ -1,3 +1,21 @@
-import config from "ui/src/tamagui.config";
+import { createAnimations } from "@tamagui/animations-css";
+import { createTamagui, baseConfig } from "ui/src/tamagui.config";
 
-export default config;
+const appConfig = createTamagui({
+  ...baseConfig,
+  animations: createAnimations({
+    fast: "ease-in 150ms",
+    medium: "ease-in 300ms",
+    slow: "ease-in 450ms",
+  }),
+});
+
+export type AppConfig = typeof appConfig;
+
+declare module "@tamagui/core" {
+  // overrides TamaguiCustomConfig so your custom types
+  // work everywhere you import `tamagui`
+  interface TamaguiCustomConfig extends AppConfig {}
+}
+
+export default appConfig;

--- a/apps/web/src/utils/route.util.ts
+++ b/apps/web/src/utils/route.util.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { GUEST_PATHS, SYSTEM_PATHS } from "../constants";
+import { GUEST_PATHS, SYSTEM_PATHS, GUEST_ENTRY_PATH } from "../constants";
 import { ReduxPersistCookie } from "../utils/cookie.utils";
 import { type PersistedAuthObject } from "../types/auth.types";
 import { authService } from "src/services";
@@ -10,8 +10,8 @@ const EMPTY_PROPS = {
 };
 
 export async function routeProtector(req: NextRequest) {
-  const onGuestPath = GUEST_PATHS.includes(req.url);
-  const onLoginPage = req.url === "/login";
+  const onAGuestPath = GUEST_PATHS.includes(req.url);
+  const onGuestEntryPath = req.url === GUEST_ENTRY_PATH;
   const onSystemPath = SYSTEM_PATHS.some((path) => req.url.startsWith(path));
 
   try {
@@ -29,29 +29,29 @@ export async function routeProtector(req: NextRequest) {
 
     const hasValidSession = await authService.validateWithAuthId(authId);
 
-    if (onGuestPath && hasValidSession) {
+    if (onAGuestPath && hasValidSession) {
       return {
         redirect: {
           permanent: false,
           destination: "/",
         },
       };
-    } else if (!onGuestPath && !onSystemPath && !hasValidSession) {
+    } else if (!onAGuestPath && !onSystemPath && !hasValidSession) {
       return {
         redirect: {
           permanent: false,
-          destination: "/login",
+          destination: GUEST_ENTRY_PATH,
         },
       };
     }
   } catch (e) {
     // TODO remove this
     console.log("something failed", e);
-    if (!onLoginPage) {
+    if (!onGuestEntryPath) {
       return {
         redirect: {
           permanent: false,
-          destination: "/login",
+          destination: GUEST_ENTRY_PATH,
         },
       };
     }

--- a/packages/app/src/screens/DecadeStats.screen.tsx
+++ b/packages/app/src/screens/DecadeStats.screen.tsx
@@ -11,7 +11,7 @@ const DecadeStatsScreen = () => {
   const countryList = useSelector(selectCountryList);
   const dispatch = useDispatch();
   return (
-    <YStack>
+    <YStack fullscreen>
       <Paragraph>Api v1: {process.env.NEXT_PUBLIC_API_V1_URL}</Paragraph>
       <Input
         onChangeText={(e) => {

--- a/packages/app/src/screens/Evm.screen.tsx
+++ b/packages/app/src/screens/Evm.screen.tsx
@@ -1,0 +1,25 @@
+import { YStack, H1, Paragraph, Button } from "ui";
+import { useRouter } from "solito/router";
+
+const EvmScreen = () => {
+  const { back } = useRouter();
+
+  return (
+    <YStack fullscreen>
+      <YStack
+        flexGrow={1}
+        padding="$4"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <H1>Evm</H1>
+        <Paragraph>Login with evm identity</Paragraph>
+      </YStack>
+      <YStack padding="$4">
+        <Button onPress={() => back()}>Try another method</Button>
+      </YStack>
+    </YStack>
+  );
+};
+
+export default EvmScreen;

--- a/packages/app/src/screens/Home.screen.tsx
+++ b/packages/app/src/screens/Home.screen.tsx
@@ -8,7 +8,7 @@ const HomeScreen = () => {
   const { push } = useRouter();
 
   return (
-    <YStack padding="$4">
+    <YStack padding="$4" fullscreen>
       <CustomHeader>Hi Hello Howdy!</CustomHeader>
       <CustomInput />
       <Spacer />

--- a/packages/app/src/screens/Login.screen.tsx
+++ b/packages/app/src/screens/Login.screen.tsx
@@ -12,6 +12,7 @@ import {
   FormMessage,
 } from "ui";
 import { useLogin, type LoginStatus } from "../hooks/auth.hooks";
+import { useRouter } from "solito/router";
 
 type InputFieldProps = {
   // TODO remove `any type
@@ -19,9 +20,6 @@ type InputFieldProps = {
   fieldName: string;
   label: string;
   autoCorrect: boolean;
-  // secureTextEntry: boolean;
-  // inputMode: Parameters<typeof Input>[0]["inputMode"];
-  // textContentType: Parameters<typeof Input>[0]["textContentType"];
 } & Parameters<typeof Input>[0];
 
 const InputField: FC<InputFieldProps> = ({
@@ -29,9 +27,6 @@ const InputField: FC<InputFieldProps> = ({
   fieldName,
   label,
   ...inputProps
-  // autoCorrect,
-  // inputMode,
-  // textContentType,
 }) => {
   const touched = formik.touched[fieldName];
   const errors = formik.errors[fieldName];
@@ -66,9 +61,6 @@ const InputField: FC<InputFieldProps> = ({
         value={formik.values[fieldName]}
         onChangeText={formik.handleChange(fieldName)}
         {...inputProps}
-        // autoCorrect={autoCorrect}
-        // inputMode={inputMode}
-        // textContentType={textContentType}
       />
     </YStack>
   );
@@ -154,14 +146,17 @@ const FormSubmit: FC<FormSubmitProps> = ({ formik, status }) => {
 
 const LoginScreen = () => {
   const { formik, status } = useLogin();
+  const { back } = useRouter();
 
   return (
-    <YStack>
+    <YStack fullscreen>
       <Form
+        flexGrow={1}
         paddingTop="$4"
         paddingBottom="$4"
         onSubmit={formik.handleSubmit}
         space="$2"
+        justifyContent="center"
       >
         <InputField
           formik={formik}
@@ -181,52 +176,6 @@ const LoginScreen = () => {
           secureTextEntry={true}
           textContentType="password"
         />
-        {/* <Label htmlFor="username">Username</Label>
-        <Input
-          id="username"
-          disabled={formik.isSubmitting}
-          // editable={!formik.isSubmitting}
-          editable={!formik.isSubmitting}
-          autoCorrect={false}
-          onChangeText={formik.handleChange("username")}
-          onBlur={formik.handleBlur("username")}
-          value={formik.values.username}
-          inputMode="text"
-          textContentType="username"
-          autoFocus
-          style={{
-            borderColor:
-              !!formik.touched.username && !!formik.errors.username
-                ? "#F00"
-                : undefined,
-          }}
-        />
-        {!!formik.touched.username && !!formik.errors.username ? (
-          <InputMessage type="error">{formik.errors.username}</InputMessage>
-        ) : null} */}
-
-        {/* <Label htmlFor="username">Password</Label>
-        <Input
-          id="password"
-          autoCorrect={false}
-          disabled={formik.isSubmitting}
-          editable={!formik.isSubmitting}
-          onChangeText={formik.handleChange("password")}
-          onBlur={formik.handleBlur("password")}
-          value={formik.values.password}
-          secureTextEntry={true}
-          inputMode="text"
-          textContentType="password"
-          style={{
-            borderColor:
-              !!formik.touched.password && !!formik.errors.password
-                ? "#F00"
-                : undefined,
-          }}
-        />
-        {!!formik.touched.password && !!formik.errors.password ? (
-          <InputMessage type="error">{formik.errors.password}</InputMessage>
-        ) : null} */}
         <XStack
           justifyContent="space-between"
           paddingLeft="$4"
@@ -243,19 +192,15 @@ const LoginScreen = () => {
             }
             checked={formik.values.rememberMe}
           >
-            <Switch.Thumb animation="quick" />
+            <Switch.Thumb animation="fast" />
           </Switch>
         </XStack>
 
-        <FormSubmit
-          formik={formik}
-          // status={isError ? "error" : "idle"}
-          // isSuccess={isSuccess}
-          // isError={isError}
-          // isLoginFailed={isLoginFailed}
-          status={status}
-        />
+        <FormSubmit formik={formik} status={status} />
       </Form>
+      <YStack padding="$4">
+        <Button onPress={() => back()}>Try another method</Button>
+      </YStack>
     </YStack>
   );
 };

--- a/packages/app/src/screens/Logout.screen.tsx
+++ b/packages/app/src/screens/Logout.screen.tsx
@@ -1,18 +1,19 @@
-import { Paragraph, YStack } from "ui";
+import { Paragraph, YStack, H1 } from "ui";
 import { useLogout } from "../hooks/auth.hooks";
 
 const LogoutScreen = () => {
   const { isLoading } = useLogout();
 
-  if (isLoading) {
-    <YStack padding="$4">
-      <Paragraph>Logging out...</Paragraph>
-    </YStack>;
-  }
+  const MessageComponent = isLoading ? (
+    <Paragraph>Logging out…</Paragraph>
+  ) : (
+    <Paragraph>Redirecting…</Paragraph>
+  );
 
   return (
-    <YStack padding="$4">
-      <Paragraph>Redirecting...</Paragraph>
+    <YStack padding="$4" fullscreen alignItems="center" justifyContent="center">
+      <H1>Logout</H1>
+      {MessageComponent}
     </YStack>
   );
 };

--- a/packages/app/src/screens/Welcome.screen.tsx
+++ b/packages/app/src/screens/Welcome.screen.tsx
@@ -1,0 +1,32 @@
+import { H1, Paragraph, YStack, Button } from "ui";
+import { useRouter } from "solito/router";
+
+const WelcomeScreen = () => {
+  const { push } = useRouter();
+
+  return (
+    <YStack padding="$4" fullscreen>
+      <YStack
+        paddingBottom="$4"
+        flexGrow={1}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <H1>NextJS gRPC</H1>
+        <Paragraph>
+          This is a technical project with no predetermined use case
+        </Paragraph>
+      </YStack>
+      <YStack space>
+        <Button onPress={() => push({ pathname: "/login" })}>
+          Login with Userpass
+        </Button>
+        <Button onPress={() => push({ pathname: "/evm" })}>
+          Login EVM identity
+        </Button>
+      </YStack>
+    </YStack>
+  );
+};
+
+export default WelcomeScreen;

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -14,7 +14,7 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "strict": false,
-    "target": "es5"
+    "target": "es6"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/packages/ui/src/Provider.tsx
+++ b/packages/ui/src/Provider.tsx
@@ -1,11 +1,9 @@
 import type { FC, ReactNode } from "react";
-import { TamaguiProvider } from "tamagui";
-
-import tamaguiConfig from "./tamagui.config";
+import { TamaguiProvider, createTamagui } from "tamagui";
 
 type UiProviderProps = typeof TamaguiProvider & {
   children: ReactNode;
-  config: typeof tamaguiConfig;
+  config: ReturnType<typeof createTamagui>;
 };
 
 const UiProvider: FC<UiProviderProps> = ({ children, config, ...rest }) => {

--- a/packages/ui/src/tamagui.config.ts
+++ b/packages/ui/src/tamagui.config.ts
@@ -1,19 +1,7 @@
 import { config } from "@tamagui/config";
-// import * as ReactNative from "react-native";
-import { createTamagui } from "tamagui"; // or '@tamagui/core'
+export { createTamagui } from "tamagui"; // or '@tamagui/core'
 
 // if using only @tamagui/core with `react-native` components
 // if using `tamagui` this isn't necessary
 // setupReactNative(ReactNative);
-
-const appConfig = createTamagui(config);
-
-export type AppConfig = typeof appConfig;
-
-declare module "@tamagui/core" {
-  // overrides TamaguiCustomConfig so your custom types
-  // work everywhere you import `tamagui`
-  interface TamaguiCustomConfig extends AppConfig {}
-}
-
-export default appConfig;
+export const baseConfig = config;


### PR DESCRIPTION
- Create welcome page for the guest entrypoint.
- Create Evm page for hosting evm identity based login, this page is
  empty for now.
- Refactor `tamagui.config` in `ui` `web` and `android` to allow
  separate configuration values for different platforms. The current
  refactoring also allows a base config for all platforms, however this
  isn't used in the apps for now as the ui customization is planned for
  the future.
- Update route guards to redirect to welcome page instead of login.
- Minor styling updates in currently existing screens. The changes
  wouldn't be noticeable to a user.
- Update nextjs js target as ES6. This is done because the previous
  setting of ES5 did not allow certain features such as `const` that
  were required.
