### PR TITLE
Feat: Add mock responses for `api/v1/decadeStats`

### DIFF
--- a/packages/app/src/api/v1/decade-stats.ts
+++ b/packages/app/src/api/v1/decade-stats.ts
@@ -1,11 +1,19 @@
 import { InflationService } from "../../services/inflation/inflation.service";
 import { getTlsProps } from "../../utils/readCertPath";
+import { MockData } from "../../utils/mock-data.utils";
 
 export const tlsProps = getTlsProps();
+
+console.log({ MOCK_ENDPOINTS: process.env.MOCK_ENDPOINTS });
 
 // TODO this route needs authorization
 export async function inflationApi(codes: string[]) {
   try {
+    if (process.env.MOCK_ENDPOINTS === "true") {
+      const mockData = await MockData.decadeStats(codes);
+      return { decadeStats: mockData };
+    }
+
     const inflationService = new InflationService(tlsProps);
     const response = await inflationService.decadeStats(codes);
     return { decadeStats: response };

--- a/packages/app/src/layouts/DecadeStatsCardList.layout.tsx
+++ b/packages/app/src/layouts/DecadeStatsCardList.layout.tsx
@@ -1,5 +1,5 @@
 import { type FC } from "react";
-import { YStack, Text, DecadeStatsCardView } from "ui";
+import { YStack, Text, DecadeStatsCardView, ScrollView } from "ui";
 import {
   useInflationDecadeStats,
   useSelector,
@@ -31,10 +31,12 @@ export const DecadeStatsCardListLayout: FC<
   }
 
   return (
-    <YStack>
-      {data.decadeStats.map((item) => (
-        <DecadeStatsCardView key={item.countryCode} item={item} />
-      ))}
-    </YStack>
+    <ScrollView>
+      <YStack>
+        {data.decadeStats.map((item) => (
+          <DecadeStatsCardView key={item.countryCode} item={item} />
+        ))}
+      </YStack>
+    </ScrollView>
   );
 };

--- a/packages/app/src/utils/mock-data.utils.ts
+++ b/packages/app/src/utils/mock-data.utils.ts
@@ -1,0 +1,31 @@
+export class MockData {
+  // TODO any
+  public static decadeStats(codes: string[]): Promise<any> {
+    const data =
+      codes[0] === ""
+        ? []
+        : codes
+            .map((code) =>
+              Array(2)
+                .fill(null)
+                .map((_, i) => ({
+                  countryCode: `${code.toUpperCase()}-${i}`,
+                  countryName: code.toLowerCase(),
+                  decade: i,
+                  count: i,
+                  average: i,
+                  max: i,
+                  min: i,
+                  median: i,
+                  range: i,
+                  stdDev: i,
+                  variance: i,
+                }))
+            )
+            .reduce((p, c) => {
+              p = [...p, ...c];
+              return p;
+            }, []);
+    return Promise.resolve(data);
+  }
+}

--- a/packages/ui/src/views/DecadeStatsCard.view.tsx
+++ b/packages/ui/src/views/DecadeStatsCard.view.tsx
@@ -1,4 +1,4 @@
-import { Card, H2, Text, H1 } from "tamagui";
+import { Card, H2, Text, H1, ListItem } from "tamagui";
 import { type FC } from "react";
 
 interface DecadeStatsCardViewProps {


### PR DESCRIPTION
- Above-mentioned api can now send mock responses. This is useful for
  dev environments when the backend services aren't available.
- Alter DecadeStatsCardListLayout component so it would scroll as
  expected.
