### PR TITLE
Feat: Error Boundaries

### DIFF
--- a/apps/android/src/App.tsx
+++ b/apps/android/src/App.tsx
@@ -16,6 +16,8 @@ import {
   WALLET_CONNECT_ANDROID_METADATA,
 } from "web3";
 import { SolitoImageProvider } from "solito/image";
+import { ErrorBoundary } from "app";
+import { RnAppFallback } from "./fallbacks/App.fallback";
 
 /**
  * @dev
@@ -36,32 +38,34 @@ const App = () => {
   );
 
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <SafeAreaProvider>
-        <StoreProvider store={store} loadingViewComponent={null}>
-          <UiProvider
-            config={tamaguiConfig}
-            // @ts-ignore: #1
-            disableInjectCSS
-            defaultTheme={colorScheme}
-            disableRootThemeClass>
-            <SolitoImageProvider
-              // @ts-ignore
-              nextJsURL={process.env.NEXT_PUBLIC_WEB_APP_URL!}
-              // loader={({ quality, width, src }) => {
-              //   return `https://cloudinary.com/${src}?w=${width}&q=${quality}`;
-              //             }}
-            >
-              <RootNavigator />
-            </SolitoImageProvider>
-          </UiProvider>
-        </StoreProvider>
-        <Web3Modal
-          projectId={WALLET_CONNECT_PROJECT_ID}
-          providerMetadata={WALLET_CONNECT_ANDROID_METADATA}
-        />
-      </SafeAreaProvider>
-    </GestureHandlerRootView>
+    <ErrorBoundary FallbackComponent={RnAppFallback}>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <SafeAreaProvider>
+          <StoreProvider store={store} loadingViewComponent={null}>
+            <UiProvider
+              config={tamaguiConfig}
+              // @ts-ignore: #1
+              disableInjectCSS
+              defaultTheme={colorScheme}
+              disableRootThemeClass>
+              <SolitoImageProvider
+                // @ts-ignore
+                nextJsURL={process.env.NEXT_PUBLIC_WEB_APP_URL!}
+                // loader={({ quality, width, src }) => {
+                //   return `https://cloudinary.com/${src}?w=${width}&q=${quality}`;
+                //             }}
+              >
+                <RootNavigator />
+              </SolitoImageProvider>
+            </UiProvider>
+          </StoreProvider>
+          <Web3Modal
+            projectId={WALLET_CONNECT_PROJECT_ID}
+            providerMetadata={WALLET_CONNECT_ANDROID_METADATA}
+          />
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
+    </ErrorBoundary>
   );
 };
 

--- a/apps/android/src/fallbacks/App.fallback.tsx
+++ b/apps/android/src/fallbacks/App.fallback.tsx
@@ -1,0 +1,29 @@
+import { Text, View, StyleSheet, TouchableOpacity } from "react-native";
+import { useErrorBoundary } from "app";
+
+export const RnAppFallback = () => {
+  const { resetBoundary } = useErrorBoundary();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>OOpsie</Text>
+      <TouchableOpacity onPress={resetBoundary}>
+        <Text>Reset Boundary</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+  title: {
+    color: "#F00",
+    fontSize: 50,
+  },
+});

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -26,7 +26,7 @@ function App(appProps: AppPropsWithLayout) {
   const { store, props } = wrapper.useWrappedStore(appProps);
 
   return (
-    // @ts-expect-error #1
+    /* @ts-expect-error #1 */
     <StoreProvider store={store} loadingViewComponent={null}>
       <ClientSideRouteGuardProvider>
         <WebThemeProvider {...props} />

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "formik": "^2.4.0",
     "i18n": "*",
+    "react-error-boundary": "^4.0.10",
     "solito": "^3.2.6",
     "store": "*",
     "ui": "*",

--- a/packages/app/src/fallbacks/Layout.fallback.tsx
+++ b/packages/app/src/fallbacks/Layout.fallback.tsx
@@ -1,0 +1,20 @@
+import { type FC } from "react";
+import { Button, Paragraph, YStack, Spacer, H3, SizableText } from "ui";
+import { type FallbackProps } from "react-error-boundary";
+
+export const LayoutFallback: FC<FallbackProps> = ({
+  error,
+  resetErrorBoundary,
+}) => {
+  return (
+    <YStack>
+      <H3 textAlign="center">Layout Fallback</H3>
+      <Paragraph style={{ color: "red" }} textAlign="center">
+        {error.message}
+      </Paragraph>
+      <Button onPress={resetErrorBoundary}>
+        <SizableText>Reset Boundary</SizableText>
+      </Button>
+    </YStack>
+  );
+};

--- a/packages/app/src/fallbacks/Screen.fallback.tsx
+++ b/packages/app/src/fallbacks/Screen.fallback.tsx
@@ -1,0 +1,19 @@
+import { type FC } from "react";
+import { Button, Paragraph, YStack, Spacer, H3 } from "ui";
+import { type FallbackProps } from "react-error-boundary";
+
+export const ScreenFallback: FC<FallbackProps> = ({
+  error,
+  resetErrorBoundary,
+}) => {
+  return (
+    <YStack fullscreen justifyContent="center" alignItems="center">
+      <H3>Screen Fallback</H3>
+      <Spacer />
+      <Paragraph>Error Message:</Paragraph>
+      <Paragraph style={{ color: "red" }}>{error.message}</Paragraph>
+      <Spacer />
+      <Button onPress={resetErrorBoundary}>Reset Boundary</Button>
+    </YStack>
+  );
+};

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,2 +1,4 @@
 export * from "./screens/Home.screen";
 export * from "./screens/User.screen";
+
+export { ErrorBoundary, useErrorBoundary } from "react-error-boundary";

--- a/packages/app/src/screens/DecadeStats.screen.tsx
+++ b/packages/app/src/screens/DecadeStats.screen.tsx
@@ -1,4 +1,4 @@
-import { YStack, Spacer, Input, Paragraph, ScrollView, Stack } from "ui";
+import { Spacer, Input, Paragraph, ScrollView, Stack } from "ui";
 import {
   setCountries,
   useSelector,
@@ -6,24 +6,28 @@ import {
   useDispatch,
 } from "store";
 import { DecadeStatsCardListLayout } from "../layouts/DecadeStatsCardList.layout";
+import { ErrorBoundary } from "react-error-boundary";
+import { ScreenFallback } from "../fallbacks/Screen.fallback";
 
 const DecadeStatsScreen = () => {
   const countryList = useSelector(selectCountryList);
   const dispatch = useDispatch();
   return (
-    <ScrollView>
-      <Stack paddingLeft="$4" paddingRight="$4">
-        <Paragraph>Api v1: {process.env.NEXT_PUBLIC_API_V1_URL}</Paragraph>
-        <Input
-          onChangeText={(e) => {
-            return dispatch(setCountries(e));
-          }}
-          value={countryList}
-        />
-      </Stack>
-      <Spacer />
-      <DecadeStatsCardListLayout />
-    </ScrollView>
+    <ErrorBoundary FallbackComponent={ScreenFallback}>
+      <ScrollView>
+        <Stack paddingLeft="$4" paddingRight="$4">
+          <Paragraph>Api v1: {process.env.NEXT_PUBLIC_API_V1_URL}</Paragraph>
+          <Input
+            onChangeText={(e) => {
+              return dispatch(setCountries(e));
+            }}
+            value={countryList}
+          />
+        </Stack>
+        <Spacer />
+        <DecadeStatsCardListLayout />
+      </ScrollView>
+    </ErrorBoundary>
   );
 };
 

--- a/packages/app/src/screens/Evm.screen.tsx
+++ b/packages/app/src/screens/Evm.screen.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "solito/router";
 import { type Web3ConnectionOptionsProps, web3Service } from "web3";
 import { useSelector, selectDrivers } from "store";
 import BalanceLayout from "../layouts/Balance.layout";
+import { ErrorBoundary } from "react-error-boundary";
+import { ScreenFallback } from "../fallbacks/Screen.fallback";
 
 interface EvmScreenProps {
   // EvmConnectionOptionsComponent: FC<Web3ConnectionOptionsProps>;
@@ -19,24 +21,26 @@ const EvmScreen: FC<EvmScreenProps> = () => {
   const driverStates = useSelector(selectDrivers);
 
   return (
-    <YStack fullscreen>
-      <YStack
-        flexGrow={1}
-        padding="$4"
-        alignItems="center"
-        justifyContent="center"
-      >
-        <H1>Evm</H1>
-        <Paragraph>Login with evm identity</Paragraph>
-        <Spacer />
-        <EvmConnectionOptions driverStates={driverStates} />
-        <Spacer />
+    <ErrorBoundary FallbackComponent={ScreenFallback}>
+      <YStack fullscreen>
+        <YStack
+          flexGrow={1}
+          padding="$4"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <H1>Evm</H1>
+          <Paragraph>Login with evm identity</Paragraph>
+          <Spacer />
+          <EvmConnectionOptions driverStates={driverStates} />
+          <Spacer />
+        </YStack>
+        <BalanceLayout />
+        <YStack padding="$4">
+          <Button onPress={() => back()}>Try another method</Button>
+        </YStack>
       </YStack>
-      <BalanceLayout />
-      <YStack padding="$4">
-        <Button onPress={() => back()}>Try another method</Button>
-      </YStack>
-    </YStack>
+    </ErrorBoundary>
   );
 };
 

--- a/packages/app/src/screens/Home.screen.tsx
+++ b/packages/app/src/screens/Home.screen.tsx
@@ -9,98 +9,129 @@ import {
   XStack,
   Button,
   Icons,
-  Paragraph,
   ScrollView,
   Group,
+  SizableText,
 } from "ui";
 import { SolitoImage } from "solito/image";
 import { useTranslation } from "i18n";
+import { ErrorBoundary, useErrorBoundary } from "react-error-boundary";
+import { ScreenFallback } from "../fallbacks/Screen.fallback";
+import { LayoutFallback } from "../fallbacks/Layout.fallback";
 
 const HomeScreen = () => {
   const { push } = useRouter();
   const { t } = useTranslation(["rest"]);
 
   return (
-    <ScrollView>
-      <YStack>
-        <Spacer />
-        <XStack
-          justifyContent="space-between"
-          marginBottom="$6"
-          alignItems="center"
-          paddingLeft="$4"
-          paddingRight="$4"
-        >
-          <CustomHeader>{t`rest:FeedScreen.Greeting`}</CustomHeader>
-          <Group orientation="horizontal">
-            <Group.Item>
-              <Button
-                onPress={() =>
-                  push({
-                    pathname: "/settings",
-                  })
-                }
-              >
-                <Icons.User />
-              </Button>
-            </Group.Item>
-            <Group.Item>
-              <Button
-                onPress={() =>
-                  push({
-                    pathname: "/settings",
-                  })
-                }
-              >
-                <Icons.Settings />
-              </Button>
-            </Group.Item>
-          </Group>
-        </XStack>
-        <Stack paddingLeft="$4" paddingRight="$4">
-          <CustomInput />
-        </Stack>
-        <Spacer />
-        {/* @ts-ignore */}
+    <ErrorBoundary FallbackComponent={ScreenFallback}>
+      <ScrollView>
         <YStack>
-          {Array(6)
-            .fill(null)
-            .map((_, i) => (
-              <Stack key={i}>
-                <Stack height={300} key={i} borderRadius="$4" overflow="hidden">
-                  {/* @ts-expect-error */}
-                  <SolitoImage
-                    src={`/mock/image-${i}.jpg`}
-                    fill
-                    resizeMode="cover"
-                    alt="A cool image, imported locally."
-                  />
+          <Spacer />
+          <XStack
+            justifyContent="space-between"
+            marginBottom="$6"
+            alignItems="center"
+            paddingLeft="$4"
+            paddingRight="$4"
+          >
+            <CustomHeader>{t`rest:FeedScreen.Greeting`}</CustomHeader>
+            <Group orientation="horizontal">
+              <Group.Item>
+                <Button
+                  onPress={() =>
+                    push({
+                      pathname: "/settings",
+                    })
+                  }
+                >
+                  <Icons.User />
+                </Button>
+              </Group.Item>
+              <Group.Item>
+                <Button
+                  onPress={() =>
+                    push({
+                      pathname: "/settings",
+                    })
+                  }
+                >
+                  <Icons.Settings />
+                </Button>
+              </Group.Item>
+            </Group>
+          </XStack>
+          <Stack paddingLeft="$4" paddingRight="$4">
+            <CustomInput />
+          </Stack>
+          <Spacer />
+          {/* @ts-ignore */}
+          <YStack>
+            {Array(6)
+              .fill(null)
+              .map((_, i) => (
+                <Stack key={i}>
+                  <Stack
+                    height={300}
+                    key={i}
+                    borderRadius="$4"
+                    overflow="hidden"
+                  >
+                    {/* @ts-expect-error */}
+                    <SolitoImage
+                      src={`/mock/image-${i}.jpg`}
+                      fill
+                      resizeMode="cover"
+                      alt="A cool image, imported locally."
+                    />
+                  </Stack>
+                  <Spacer />
                 </Stack>
-                <Spacer />
-              </Stack>
-            ))}
+              ))}
+          </YStack>
+          <XStack
+            paddingLeft="$4"
+            paddingRight="$4"
+            justifyContent="space-evenly"
+          >
+            <CustomButton userId={1} flex={1}>
+              One
+            </CustomButton>
+            <Spacer />
+            <CustomButton userId={2} flex={1}>
+              Two
+            </CustomButton>
+            <Spacer />
+            <CustomButton userId={3} flex={1}>
+              Three
+            </CustomButton>
+          </XStack>
+          <Spacer />
+          <ErrorBoundary FallbackComponent={LayoutFallback}>
+            <ErrorThrowingComponent />
+          </ErrorBoundary>
+          <Spacer size="$14" />
         </YStack>
-        <XStack
-          paddingLeft="$4"
-          paddingRight="$4"
-          justifyContent="space-evenly"
-        >
-          <CustomButton userId={1} flex={1}>
-            One
-          </CustomButton>
-          <Spacer />
-          <CustomButton userId={2} flex={1}>
-            Two
-          </CustomButton>
-          <Spacer />
-          <CustomButton userId={3} flex={1}>
-            Three
-          </CustomButton>
-        </XStack>
-        <Spacer />
-        <Spacer size="$12" />
-      </YStack>
-    </ScrollView>
+      </ScrollView>
+    </ErrorBoundary>
+  );
+};
+
+const ErrorThrowingComponent = () => {
+  const { showBoundary } = useErrorBoundary();
+
+  return (
+    <Stack paddingLeft="$4" paddingRight="$4">
+      <Button
+        onPress={() => {
+          showBoundary(
+            new Error(`Custom error: ${Math.random().toString().slice(-4)}`)
+          );
+        }}
+      >
+        <SizableText>Trigger error</SizableText>
+      </Button>
+    </Stack>
   );
 };
 

--- a/packages/app/src/screens/Login.screen.tsx
+++ b/packages/app/src/screens/Login.screen.tsx
@@ -12,6 +12,8 @@ import {
 } from "ui";
 import { useLogin, type LoginStatus } from "../hooks/auth.hooks";
 import { useRouter } from "solito/router";
+import { ErrorBoundary } from "react-error-boundary";
+import { ScreenFallback } from "../fallbacks/Screen.fallback";
 
 type InputFieldProps = {
   // TODO remove `any type
@@ -31,6 +33,7 @@ const InputField: FC<InputFieldProps> = ({
   const errors = formik.errors[fieldName];
   const status = !!touched && !!errors ? "error" : "idle";
   const colors = setFormFieldColors(status);
+
   return (
     <YStack
       backgroundColor={colors.bg}
@@ -152,59 +155,61 @@ const LoginScreen = () => {
   const { back } = useRouter();
 
   return (
-    <YStack fullscreen>
-      <Form
-        flexGrow={1}
-        paddingTop="$4"
-        paddingBottom="$4"
-        onSubmit={formik.handleSubmit}
-        space="$2"
-        justifyContent="center"
-      >
-        <InputField
-          formik={formik}
-          fieldName="username"
-          label="Username"
-          autoCorrect={false}
-          inputMode="text"
-          secureTextEntry={false}
-          textContentType="username"
-        />
-        <InputField
-          formik={formik}
-          fieldName="password"
-          label="Password"
-          autoCorrect={false}
-          inputMode="text"
-          secureTextEntry={true}
-          textContentType="password"
-        />
-        <XStack
-          justifyContent="space-between"
-          paddingLeft="$4"
-          paddingRight="$4"
-          paddingBottom="$2"
-          paddingTop="$2"
+    <ErrorBoundary FallbackComponent={ScreenFallback}>
+      <YStack fullscreen>
+        <Form
+          flexGrow={1}
+          paddingTop="$4"
+          paddingBottom="$4"
+          onSubmit={formik.handleSubmit}
+          space="$2"
+          justifyContent="center"
         >
-          <Label htmlFor="remember-me">Remember me</Label>
-          <Switch
-            id="remember-me"
-            disabled={formik.isSubmitting}
-            onCheckedChange={(rememberMe) =>
-              formik.setFieldValue("rememberMe", rememberMe)
-            }
-            checked={formik.values.rememberMe}
+          <InputField
+            formik={formik}
+            fieldName="username"
+            label="Username"
+            autoCorrect={false}
+            inputMode="text"
+            secureTextEntry={false}
+            textContentType="username"
+          />
+          <InputField
+            formik={formik}
+            fieldName="password"
+            label="Password"
+            autoCorrect={false}
+            inputMode="text"
+            secureTextEntry={true}
+            textContentType="password"
+          />
+          <XStack
+            justifyContent="space-between"
+            paddingLeft="$4"
+            paddingRight="$4"
+            paddingBottom="$2"
+            paddingTop="$2"
           >
-            <Switch.Thumb animation="fast" />
-          </Switch>
-        </XStack>
+            <Label htmlFor="remember-me">Remember me</Label>
+            <Switch
+              id="remember-me"
+              disabled={formik.isSubmitting}
+              onCheckedChange={(rememberMe) =>
+                formik.setFieldValue("rememberMe", rememberMe)
+              }
+              checked={formik.values.rememberMe}
+            >
+              <Switch.Thumb animation="fast" />
+            </Switch>
+          </XStack>
 
-        <FormSubmit formik={formik} status={status} />
-      </Form>
-      <YStack padding="$4">
-        <Button onPress={() => back()}>Try another method</Button>
+          <FormSubmit formik={formik} status={status} />
+        </Form>
+        <YStack padding="$4">
+          <Button onPress={() => back()}>Try another method</Button>
+        </YStack>
       </YStack>
-    </YStack>
+    </ErrorBoundary>
   );
 };
 

--- a/packages/app/src/screens/Logout.screen.tsx
+++ b/packages/app/src/screens/Logout.screen.tsx
@@ -1,6 +1,8 @@
 import { Paragraph, YStack, H1 } from "ui";
 import { useTranslation } from "i18n";
 import { useLogout } from "../hooks/auth.hooks";
+import { ErrorBoundary } from "react-error-boundary";
+import { ScreenFallback } from "../fallbacks/Screen.fallback";
 
 const LogoutScreen = () => {
   const { isLoading } = useLogout();
@@ -13,10 +15,17 @@ const LogoutScreen = () => {
   );
 
   return (
-    <YStack padding="$4" fullscreen alignItems="center" justifyContent="center">
-      <H1>{t`rest:LogoutScreen.Logout`}</H1>
-      {MessageComponent}
-    </YStack>
+    <ErrorBoundary FallbackComponent={ScreenFallback}>
+      <YStack
+        padding="$4"
+        fullscreen
+        alignItems="center"
+        justifyContent="center"
+      >
+        <H1>{t`rest:LogoutScreen.Logout`}</H1>
+        {MessageComponent}
+      </YStack>
+    </ErrorBoundary>
   );
 };
 

--- a/packages/app/src/screens/Settings.screen.tsx
+++ b/packages/app/src/screens/Settings.screen.tsx
@@ -1,39 +1,43 @@
 import { useRouter } from "solito/router";
 import { YStack, Button, Spacer, H3, YGroup, Separator } from "ui";
 import { useTranslation, LANGUAGES } from "i18n";
+import { ErrorBoundary } from "react-error-boundary";
+import { ScreenFallback } from "../fallbacks/Screen.fallback";
 
 const SettingsScreen = () => {
   const { push, back } = useRouter();
   const { t, i18n } = useTranslation(["rest"]);
 
   return (
-    <YStack padding="$4">
-      <Button onPress={() => back()}>{t("global:Prompts.Back")}</Button>
-      <Spacer />
+    <ErrorBoundary FallbackComponent={ScreenFallback}>
+      <YStack padding="$4">
+        <Button onPress={() => back()}>{t("global:Prompts.Back")}</Button>
+        <Spacer />
 
-      <H3>{t`rest:SettingsScreen.LanguageOptions.Title`}</H3>
-      <Spacer size="$4" />
-      <YGroup separator={<Separator />}>
-        {LANGUAGES.map(({ label, code }) => (
-          <YGroup.Item key={label}>
-            <Button onPress={() => i18n.changeLanguage(code)}>{label}</Button>
-          </YGroup.Item>
-        ))}
-      </YGroup>
-      <Spacer size="$6" />
+        <H3>{t`rest:SettingsScreen.LanguageOptions.Title`}</H3>
+        <Spacer size="$4" />
+        <YGroup separator={<Separator />}>
+          {LANGUAGES.map(({ label, code }) => (
+            <YGroup.Item key={label}>
+              <Button onPress={() => i18n.changeLanguage(code)}>{label}</Button>
+            </YGroup.Item>
+          ))}
+        </YGroup>
+        <Spacer size="$6" />
 
-      <H3>{t`rest:SettingsScreen.AccountManagement.Title`}</H3>
-      <Spacer size="$4" />
-      <Button
-        onPress={() =>
-          push({
-            pathname: "/logout",
-          })
-        }
-      >
-        {t`rest:SettingsScreen.Logout`}
-      </Button>
-    </YStack>
+        <H3>{t`rest:SettingsScreen.AccountManagement.Title`}</H3>
+        <Spacer size="$4" />
+        <Button
+          onPress={() =>
+            push({
+              pathname: "/logout",
+            })
+          }
+        >
+          {t`rest:SettingsScreen.Logout`}
+        </Button>
+      </YStack>
+    </ErrorBoundary>
   );
 };
 

--- a/packages/app/src/screens/Welcome.screen.tsx
+++ b/packages/app/src/screens/Welcome.screen.tsx
@@ -10,6 +10,8 @@ import {
   useSelector,
   selectIsAuthChecksComplete,
 } from "store";
+import { ErrorBoundary } from "react-error-boundary";
+import { ScreenFallback } from "../fallbacks/Screen.fallback";
 
 const WelcomeScreen = () => {
   const [isComponentsEnabled, setIsComponentsEnabled] = useState(false);
@@ -29,39 +31,41 @@ const WelcomeScreen = () => {
   }, [isInitializedGuest]);
 
   return (
-    <HeroLoadingLayout
-      {...(isComponentsEnabled && {
-        topComponent: (
-          <Stack
-            animation="slow"
-            enterStyle={{ opacity: 0 }}
-            opacity={1}
-            alignItems="flex-end"
-            position="absolute"
-            top="$4"
-            right="$4"
-            left="$4"
-          >
-            <CompactLanguageChangerView />
-          </Stack>
-        ),
-        mottoComponent: <WelcomeScreenMottoView />,
-        bottomComponent: (
-          <Stack
-            animation="slow"
-            position="absolute"
-            enterStyle={{ opacity: 0 }}
-            opacity={1}
-            bottom={0}
-            left={0}
-            right={0}
-            padding="$4"
-          >
-            <LoginOptionsView />
-          </Stack>
-        ),
-      })}
-    />
+    <ErrorBoundary FallbackComponent={ScreenFallback}>
+      <HeroLoadingLayout
+        {...(isComponentsEnabled && {
+          topComponent: (
+            <Stack
+              animation="slow"
+              enterStyle={{ opacity: 0 }}
+              opacity={1}
+              alignItems="flex-end"
+              position="absolute"
+              top="$4"
+              right="$4"
+              left="$4"
+            >
+              <CompactLanguageChangerView />
+            </Stack>
+          ),
+          mottoComponent: <WelcomeScreenMottoView />,
+          bottomComponent: (
+            <Stack
+              animation="slow"
+              position="absolute"
+              enterStyle={{ opacity: 0 }}
+              opacity={1}
+              bottom={0}
+              left={0}
+              right={0}
+              padding="$4"
+            >
+              <LoginOptionsView />
+            </Stack>
+          ),
+        })}
+      />
+    </ErrorBoundary>
   );
 };
 

--- a/packages/app/src/views/WelcomeScreenMotto.view.tsx
+++ b/packages/app/src/views/WelcomeScreenMotto.view.tsx
@@ -8,6 +8,7 @@ export const WelcomeScreenMottoView = () => {
     <Paragraph
       animation="slow"
       enterStyle={{ opacity: 0 }}
+      opacity={1}
       textAlign="center"
     >{t`guest:WelcomeScreen.Motto`}</Paragraph>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,7 +1630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.5, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.5, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.22.5
   resolution: "@babel/runtime@npm:7.22.5"
   dependencies:
@@ -7918,6 +7918,7 @@ __metadata:
     formik: ^2.4.0
     i18n: "*"
     jest: ^29.5.0
+    react-error-boundary: ^4.0.10
     solito: ^3.2.6
     store: "*"
     ui: "*"
@@ -16599,6 +16600,17 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "react-error-boundary@npm:4.0.10"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 4ad4864d2a5fc2264a24d03e83176e6a70d7adbe3c1edbdc5b0bd452a695104bc59456e23b5aea1b9729220672fe46614221daa8b3bd59327968d4aa7eb8bc71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add `react-error-boundary` to `app` package.
- Create placeholder error boundaries for screens, layouts and for rn
  app. Web app doesn't have an app fallback component as this shall be
  handled by the `_error` module.
- Wrap all screens in `ErrorBoundary`.
- Add a new component to `Home` to demonstrate the error boundary
  capabilities. All boundries ranging from the layout boundary to the
  app boundary can be triggered through disabling the parent boundaries
  one by one.
